### PR TITLE
[Feat] categorization -> 음식 카테고리 분류 API 추가

### DIFF
--- a/llmchatbot/urls.py
+++ b/llmchatbot/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('request_test/', request_test, name="request_test"),
     path('chat_with_openai/', chat_with_openai, name="chat_with_openai"),
     path('correct/', correct, name="correct"),
+    path('categorization/', categorization, name="categorization"),
 ]

--- a/llmchatbot/views.py
+++ b/llmchatbot/views.py
@@ -19,29 +19,24 @@ def request_test(request):
 def chat_with_openai(request):
     if request.method == 'POST':
         try:
-            # POST 요청의 body에서 질문 데이터 추출
             data = json.loads(request.body)
             question = data.get('question', '')
             
             if not question:
                 return JsonResponse({'error': '질문이 제공되지 않았습니다.'}, status=400)
             
-            # OpenAI 클라이언트 생성
             client = OpenAI(api_key=settings.OPENAI_API)
             
-            # OpenAI에 질문 전송
             response = client.chat.completions.create(
-                model="gpt-3.5-turbo",
+                model="gpt-4o-mini",
                 messages=[
                     {"role": "system", "content": "You are a helpful assistant."},
                     {"role": "user", "content": question}
                 ]
             )
             
-            # 응답에서 답변 추출
             answer = response.choices[0].message.content
             
-            # JSON 형태로 응답 반환
             return JsonResponse({'answer': answer})
             
         except Exception as e:
@@ -55,7 +50,6 @@ def correct(request):
         try:
             client = OpenAI(api_key=settings.OPENAI_API)
 
-            # 요청에서 JSON 데이터 파싱
             data = json.loads(request.body)
             food_name = data.get('food_name', '')
             
@@ -96,7 +90,6 @@ def correct(request):
                 max_tokens=100
             )
             
-            # API 응답에서 교정된 음식 이름 추출
             return JsonResponse(json.loads(response.choices[0].message.content))
             
         except json.JSONDecodeError:
@@ -104,5 +97,60 @@ def correct(request):
         except Exception as e:
             return JsonResponse({"error": str(e)}, status=500)
     
-    # POST 요청이 아닌 경우
+    return JsonResponse({"error": "POST 요청만 허용됩니다"}, status=405)
+
+@csrf_exempt
+def categorization(request):
+    if request.method == 'POST':
+        try:
+            client = OpenAI(api_key=settings.OPENAI_API)
+            data = json.loads(request.body)
+            food_name = data.get('food_name', '')
+            if not food_name:
+                return JsonResponse({"error": "food_name is required"}, status=400)
+            
+            response = client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": """당신은 한국 음식을 분류하는 도우미입니다.
+                        주어진 한국 음식 이름을 보고 다음 카테고리 중 하나로 분류하세요:
+                        "RICE", "NOODLE", "SOUP", "SIDE", "MAIN", "DESSERT"
+                        음식 이름에 가장 적합한 카테고리만 반환하고 다른 설명은 포함하지 마세요.
+                        주의) 반환은 무조건 6개 카테고리 중 하나여야 합니다."""
+                    },
+                    {
+                        "role": "user",
+                        "content": food_name
+                    }
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "food_category",
+                        "strict": True,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "category": {
+                                    "type": "string",
+                                    "enum": ["RICE", "NOODLE", "SOUP", "SIDE", "MAIN", "DESSERT"]
+                                }
+                            },
+                            "required": ["category"],
+                            "additionalProperties": False
+                        }
+                    }
+                },
+                max_tokens=100
+            )
+            
+            return JsonResponse(json.loads(response.choices[0].message.content))
+            
+        except json.JSONDecodeError:
+            return JsonResponse({"error": "올바르지 않은 JSON 형식입니다"}, status=400)
+        except Exception as e:
+            return JsonResponse({"error": str(e)}, status=500)
+    
     return JsonResponse({"error": "POST 요청만 허용됩니다"}, status=405)


### PR DESCRIPTION
## 음식 카테고리 분류 API 추가
### 변경 사항
- 음식 이름을 입력받아 카테고리로 분류하는 새로운 API 엔드포인트 categorization 추가

### 세부 내용
- 사용자로부터 음식 이름을 JSON 형태로 입력받아 6가지 카테고리(RICE, NOODLE, SOUP, SIDE, MAIN, DESSERT) 중 하나로 분류
- OpenAI GPT-4o 모델을 활용하여 정확한 분류 수행
- 기존 correct 함수와 유사한 구조로 설계하여 일관성 유지
- JSON Schema를 활용한 응답 포맷 통일