### PR TITLE
[Chore] update Dockerfile -> 타임아웃 설정 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ db.sqlite3
 db.sqlite3-journal
 secrets.json
 .DS_Store
+test/
 
 ### Django.Python Stack ###
 # Byte-compiled / optimized / DLL files

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . .
 RUN echo '#!/bin/bash\n\
 python generate_secrets.py\n\
 python manage.py collectstatic --noinput\n\
-gunicorn --bind 0.0.0.0:8080 config.wsgi:application\n\
+gunicorn --bind 0.0.0.0:8080 --workers 4 --timeout 300 config.wsgi:application\n\
 ' > start.sh && \
 chmod +x start.sh
 


### PR DESCRIPTION
### 요약
## 문제 인식
- llm 활용 보고서 생성 기능에서 간헐적으로 생성되지 않는 오류가 발생하였음
- gunicorn 기본 세팅으로 30초 초과시 타임아웃 오류를 발생시킴

## Dockerfile 수정
- llm 보고서는 대용량 데이터 기반 보고서를 생성하기에 30초를 초과하는 작업이 많음
- 따라서, Dockerfile의 gunicorn 세팅 부분 타임아웃을 300초로 확장 설정함