### PR TITLE
[Feat] 음식 상세 정보 분류 API 추가

### DIFF
--- a/llmchatbot/urls.py
+++ b/llmchatbot/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     ### MS팀 ai 솔루션 api
     path('correct/', correct, name="correct"),
     path('categorization/', categorization, name="categorization"),
+    path('detail_categorization/', detail_categorization, name="detail_categorization"),
     ### ai 리포트
     path('create_report/', create_report, name='create_report'),
     ### ai 챗봇


### PR DESCRIPTION
## 음식 상세 정보 분류 API 추가

### 변경 내용
- 음식 이름으로 상세 정보를 반환하는 `detail_categorization` API 엔드포인트 추가
- 음식 카테고리, 영양 정보, 알러지 정보 등 포괄적인 데이터 제공
- GPT-4o-mini 모델 사용함

### 구현 기능

- 음식 카테고리 분류 (RICE, NOODLE, SOUP, SIDE, MAIN, DESSERT)
- 영양소 정보 제공 (칼로리, 탄수화물, 단백질, 지방)
- 1인분 기준 식품 무게 정보
- 알러지 유발 성분 정보


### 예시 응답
```
{
  "mealCategory": "MAIN",
  "calorie_kcal": 450.0,
  "carb_g": 10.0,
  "protein_g": 35.0,
  "fat_g": 28.0,
  "foodWeight": "250g",
  "allergy": "대두"
}
```