### PR TITLE
[Feat] Agent 챗봇 기능 추가 & 응답 캐싱 시스템

### DIFF
--- a/llmchatbot/urls.py
+++ b/llmchatbot/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     ### ai 챗봇
     path('db_test/', db_test, name='db_test'),
     path('basic_chatbot_request/', basic_chatbot_request, name='basic_chatbot_request'),
+    path('agent_chatbot_request/', agent_chatbot_request, name='agent_chatbot_request'),
     # Swagger URL
     re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),


### PR DESCRIPTION
# Django 챗봇 업데이트 PR

## 추가된 기능 요약

### 1. 에이전트 기반 카테고리 분류
- OpenAI API를 활용하여 사용자 질문 분석 후 자동으로 카테고리 결정
- 질문 내용에 따라 FOOD_INFO 또는 FOOD_FEEDBACK_INFO 카테고리로 분류
- 카테고리 결정 과정에 대한 Chain of Thought 추론 제공

## 추가된 함수

### `determine_category(question)`
- 사용자 질문을 분석하여 적절한 카테고리 결정
- OpenAI API를 활용한 추론 과정 수행
- 카테고리와 함께 상세한 추론 과정 반환

### `agent_chatbot_request(request)`
- 카테고리 없이 질문만 받아 처리하는 새로운 엔드포인트
- 자동으로 카테고리를 결정하고 적절한 벡터 DB 활용
- Chain of Thought 추론 과정을 포함한 응답 생성

## API 엔드포인트

### 기존 엔드포인트
- `POST /api/team3/llmchatbot/basic_chatbot_request/`: 카테고리 기반 챗봇

### 신규 엔드포인트
- `POST /api/team3/llmchatbot/agent_chatbot_request/`: 에이전트 방식 챗봇

## 테스트 방법

### Postman 테스트
=> 스프링부트 쪽 동일 PR 참조